### PR TITLE
Update oplus-unlock link

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ It's possible to unlock using testpoints and [PotatoNV](https://github.com/mashe
 
 ### MediaTek
 If you own a MediaTek device exploitable by [mtkclient](https://github.com/bkerler/mtkclient) you can unlock the bootloader using that.<br/>
-If it also happens to be an OPPO/Realme device and you need to access fastboot: [oplus-unlock](https://github.com/R0rt1z2/oplus-unlock)
+If it also happens to be an OPPO/Realme device and you need to access fastboot: [lkpatcher](https://github.com/R0rt1z2/lkpatcher) ([web version](https://lkpatcher.r0rt1z2.com/))
 
 ### Unisoc
 If you own a phone with the Unisoc ud710 or ums512 SOCs you can look into this exploit: [CVE-2022-38694_unlock_bootloader](https://github.com/TomKing062/CVE-2022-38694_unlock_bootloader)


### PR DESCRIPTION
* oplus-unlock got deprecated a few months ago, point to lkpatcher instead.
* Also link the web version of lkpatcher.