### PR TITLE
Remove bruteforcing from Huawei section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Worse, on Android 10+, the unlock command has been **completely removed** from f
 
 Certain Kirin-based phones can use [PotatoNV](https://github.com/melontini/bootloader-unlock-wall-of-shame#kirin)
 
-Older models, through bruteforce:<br/>
-* [HuaweiBootloader_Bruteforce](https://github.com/rainxh11/HuaweiBootloader_Bruteforce)
-* [Huawei-Bootloader-Unlocker](https://github.com/Martazza/Huawei-Bootloader-Unlocker)
-
 Paid methods:<br/>
 I don't recommend paid methods due to general sketchiness. I have used one of these tools a while ago, it was okay.<br/>
 Through HCU-client (Not everything is supported + incredible prices [hcu-client.com](https://hcu-client.com/buy/)) or DC-Unlocker (Same problems as HCU [dc-unlocker.com](https://www.dc-unlocker.com/buy))


### PR DESCRIPTION
These methods attempt to unlock devices by guessing a 16-character code composed entirely of uppercase letters and numbers. The number of possible combinations for such a code is 36163616, considering 26 uppercase letters and 10 digits.

Even if we could process one billion (109109) guesses per second, realistically covering all combinations would take an inordinate amount of time.

The primary limitation of this procedure comes from the device's hardware, especially its bootloader and USB controller. On newer models, a reboot is required after the 4th failed attempt, a step that introduces even more delay due to the boot time required.

Additionally, the device's USB controller, which manages data transfers between the computer and the phone, has built-in thresholds to prevent excessive data traffic. These thresholds are not designed to accommodate the high volume of data transfers involved in bruteforce attempts.

Change-Id: I04fda8a8d66f5f920a7da84291fb96a77d9a641e