### PR TITLE
Move Motorola to Avoid, due to older phones being ineligible for unlocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ If you know of specific details/unlocking methods, please PR them or drop them i
 
 ### [Apple](/brands/apple/README.md)
 
-## ⚠️ Proceed with caution!
-
 ### [Motorola/Lenovo](/brands/motorola/README.md)
+
+## ⚠️ Proceed with caution!
 
 ### [OnePlus](/brands/oneplus/README.md)
 

--- a/brands/motorola/README.md
+++ b/brands/motorola/README.md
@@ -1,12 +1,13 @@
 # Motorola/Lenovo
 
-- Verdict: **⚠️ Proceed with caution!**
+- Verdict: **⛔ Avoid!**
 
 To start off, to unlock your bootloader you have to submit a request on their website, which is pretty bad on its own (*wink* [Huawei](/brands/huawei/README.md)). But how do you know if your device is unlockable? Well...
 
 * [This page][Most Devices] says that "Most of our latest devices support our bootloader unlock program."
 * [This page][Some Devices] says only "Photon Q 4G LTE, DROID RAZR M(Developer Edition), DROID RAZR HD(Developer Edition CDMA-LTE), MOTOROLA RAZR HD (Rest of World -UMTS/LTE), MOTOROLA RAZR HD (Rogers Canada - UMTS/LTE) and MOTOROLA RAZR i are supported by the Bootloader Unlock site."
 * [And from this conversation][turistu's post] [turistu](https://github.com/turistu) had with their support: "most of our E devices doesn't support bootloader unlock program. Please see below a list of devices that support the bootloader unlock program : g100, g51 , g71 , g200 , g52 , g82 , g42 , g62 , g32"
+* [This forum post][Old devices ineligible] says that once a device passes a certain age (the age not being specified), the device becomes ineligible.
 * There's also an unofficial way with CID to check if your device can be unlocked, check here: [xdaforums.com][CID check]
 
 > Moto used confusion! It seems pretty effective...
@@ -23,3 +24,4 @@ Authored by [melontini](https://github.com/melontini).
 [turistu's post]:https://xdaforums.com/t/how-to-guide-unlocking-using-deeptest-gdpr.4585829/post-88734665
 [CID check]:https://xdaforums.com/t/guide-un-locking-motorola-bootloader.4079111/post-85375429
 [Connection Required]:https://forums.lenovo.com/topic/findpost/15261/5289637/6254146
+[Old devices ineligible]:https://forums.lenovo.com/t5/MOTOROLA-Android-Developer-Community/Your-device-does-not-qualify-for-bootloader-unlocking/m-p/5234690?page=3#6297769


### PR DESCRIPTION
Motorola has said on their forums that once devices pass a certain age (someone in a Discord server I'm in said 6 years -- but i cant find any source for this), the device becomes ineligible for unlocking.

This is sketchy, and with all the issues that Motorola previously had, I think they fit better into Avoid now. 

(sidenote - as a moto user, this was really upsetting to find out)