### PR TITLE
Add new Xiaomi policy changes.

### DIFF
--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -25,6 +25,13 @@ Currently it is near impossible to unlock Xiaomi phones of the china region, esp
 >
 > If you own a Xiaomi device and your warranty has ended or you don't care for it, you should unlock your device while you can.
 
+> [!IMPORTANT]
+> Xiaomi has [updated their policies](https://github.com/user-attachments/assets/f69e5497-f9df-46c2-b726-83b5cbdb1002), further restricting bootloader unlocking.
+>
+> Starting from January 1, 2025, they will only let you unlock 1 device per year per account, instead of the current 3 devices per year. Be mindful of this when unlocking a device through official means with your account.
+>
+> As there isn't much information about this change apart from the update to their requirements, it's still unknown whether or not this will also apply to devices running MIUI.
+
 ### Devices running HyperOS (even if they were upgraded to it from MIUI)
 
 First of all we should clear up something: HyperOS is essentially a new marketing term for what would've been MIUI 15. So it's still a vendor skin/theming engine on top of Linux-based Android, it's just called HyperOS instead of MIUI as it used to be called.
@@ -45,7 +52,7 @@ That is, you can only make the request for unlocking the device inside Developer
 If [xiaomiui.net][global-requirements] is to be believed, the requirements for the Community App request are as follows:
 * Your Mi Account has been active for more than 30 days.
 * Xiaomi Community App version 5.3.31 or above.
-* You can only unlock the bootloader of 3 devices per year with your account.
+* You can only unlock the bootloader of 3 devices per year with your account. (After January 1, 2025, this limit will be changed to 1 device per year, *how cool is that?*)
 
 And it gets even better! As people have found it the hard way [in the xda forums][community-app-cap], there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time (or whatever that is in your timezone).
 

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -26,11 +26,11 @@ Currently it is near impossible to unlock Xiaomi phones of the china region, esp
 > If you own a Xiaomi device and your warranty has ended or you don't care for it, you should unlock your device while you can.
 
 > [!IMPORTANT]
-> Xiaomi has [updated their policies](https://github.com/user-attachments/assets/f69e5497-f9df-46c2-b726-83b5cbdb1002), further restricting bootloader unlocking.
+> Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking.
 >
-> Starting from January 1, 2025, they will only let you unlock 1 device per year per account, instead of the current 3 devices per year. Be mindful of this when unlocking a device through official means with your account.
+> As of January 1st, 2025, they only let you unlock 1 device per year per account, instead of the previous 3 devices per year. You should be mindful of this change when unlocking a device through official means with your account.
 >
-> As there isn't much information about this change apart from the update to their requirements, it's still unknown whether or not this will also apply to devices running MIUI.
+> As this change is shown in the Xiaomi Community app when applying for unlocking, this shouldn't affect devices running MIUI, however it's still unknown whether or not they are affected too.
 
 ### Devices running HyperOS (even if they were upgraded to it from MIUI)
 
@@ -52,7 +52,7 @@ That is, you can only make the request for unlocking the device inside Developer
 If [xiaomiui.net][global-requirements] is to be believed, the requirements for the Community App request are as follows:
 * Your Mi Account has been active for more than 30 days.
 * Xiaomi Community App version 5.3.31 or above.
-* You can only unlock the bootloader of 3 devices per year with your account. (After January 1, 2025, this limit will be changed to 1 device per year, *how cool is that?*)
+* You can only unlock the bootloader of 1 device per year with your account. (The limit was previously 3, but got reduced on January 1st, 2025, *what a good way to start the year, right?*)
 
 And it gets even better! As people have found it the hard way [in the xda forums][community-app-cap], there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time (or whatever that is in your timezone).
 
@@ -87,3 +87,4 @@ Authored by [melontini](https://github.com/melontini).
 [Xiaomi-bootloader]:https://github.com/lrh2000/Xiaomi-bootloader
 [yo-dawg-meme]:https://knowyourmeme.com/memes/xzibit-yo-dawg
 [community-app-cap]:https://xdaforums.com/t/application-quota-limit-reached.4695764/
+[updated-policies]:https://x.com/xiaomitimecom/status/1873481568569725191

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -45,9 +45,7 @@ That is, you can only make the request for unlocking the device inside Developer
 If [xiaomiui.net][global-requirements] is to be believed, the requirements for the Community App request are as follows:
 * Your Mi Account has been active for more than 30 days.
 * Xiaomi Community App version 5.3.31 or above.
-* ~~You can only unlock the bootloader of 3 devices per year with your account.~~
-
-Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking. As of January 1st, 2025, they only let you unlock 1 device per year. *What a good way to start the year, right?*
+* Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking. As of January 1st, 2025, they only let you unlock 1 device per year. *What a good way to start the year, right?*
 
 And it gets even better! As people have found it the hard way [in the xda forums][community-app-cap], there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time (or whatever that is in your timezone).
 

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -84,4 +84,4 @@ Authored by [melontini](https://github.com/melontini).
 [Xiaomi-bootloader]:https://github.com/lrh2000/Xiaomi-bootloader
 [yo-dawg-meme]:https://knowyourmeme.com/memes/xzibit-yo-dawg
 [community-app-cap]:https://xdaforums.com/t/application-quota-limit-reached.4695764/
-[updated-policies]:https://x.com/xiaomitimecom/status/1873481568569725191
+[updated-policies]:https://xiaomitime.com/xiaomi-global-bootloader-unlock-policy-has-changed-20295/

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -25,13 +25,6 @@ Currently it is near impossible to unlock Xiaomi phones of the china region, esp
 >
 > If you own a Xiaomi device and your warranty has ended or you don't care for it, you should unlock your device while you can.
 
-> [!IMPORTANT]
-> Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking.
->
-> As of January 1st, 2025, they only let you unlock 1 device per year per account, instead of the previous 3 devices per year. You should be mindful of this change when unlocking a device through official means with your account.
->
-> As this change is shown in the Xiaomi Community app when applying for unlocking, this shouldn't affect devices running MIUI, however it's still unknown whether or not they are affected too.
-
 ### Devices running HyperOS (even if they were upgraded to it from MIUI)
 
 First of all we should clear up something: HyperOS is essentially a new marketing term for what would've been MIUI 15. So it's still a vendor skin/theming engine on top of Linux-based Android, it's just called HyperOS instead of MIUI as it used to be called.
@@ -52,7 +45,9 @@ That is, you can only make the request for unlocking the device inside Developer
 If [xiaomiui.net][global-requirements] is to be believed, the requirements for the Community App request are as follows:
 * Your Mi Account has been active for more than 30 days.
 * Xiaomi Community App version 5.3.31 or above.
-* You can only unlock the bootloader of 1 device per year with your account. (The limit was previously 3, but got reduced on January 1st, 2025, *what a good way to start the year, right?*)
+* ~~You can only unlock the bootloader of 3 devices per year with your account.~~
+
+Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking. As of January 1st, 2025, they only let you unlock 1 device per year. *What a good way to start the year, right?*
 
 And it gets even better! As people have found it the hard way [in the xda forums][community-app-cap], there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time (or whatever that is in your timezone).
 
@@ -67,6 +62,8 @@ These will both (for now) allow you to continue with the good old steps, where y
 
 You should be able to use the "normal" unlock process by itself, wihtout the community app BS
 (the one descibed in the "good old MIUI days" section above).
+
+As the "1 device per year" policy is shown in the Xiaomi Community app when applying for unlocking HyperOS devices, this shouldn't affect devices running MIUI, however it's still unknown whether or not they are affected too.
 
 ## Android One
 


### PR DESCRIPTION
As of January 1, 2025, Xiaomi has further reduced the amount of devices you can unlock to 1 device per year per account.

This PR adds this information to Xiaomi's README file, warning users about this change along with ~~an image~~ _a post_ describing the policy changes.

~~An image was linked (mostly as a placeholder) as this information isn't available on a website by Xiaomi but instead available on the Xiaomi Community app when applying for unlocking, however if a better alternative to this (or anything, really) is recommended I'm open to switching to it.~~ I've changed it to a post with a link to an article made by Xiaomitime describing the change in detail. Still open to any recommendations about anything. :D