### PR TITLE
Update page for Google and move Google to avoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ The following manufacturers allow unlocking under certain conditions, such as re
 
 ### [Motorola/Lenovo](/brands/motorola/README.md)
 
-### [Google](/brands/google/README.md)
-
 ## ⚠️ Proceed with caution!
 
 The following manufacturers require an online account and/or a waiting period before unlocking.
@@ -98,6 +96,8 @@ The following manufacturers require an online account and/or a waiting period be
 ### [itel](/brands/itel/README.md)
 
 ## ℹ️ "Safe for now" :trollface: 
+
+### [Google](/brands/google/README.md)
 
 ### [Nothing](/brands/nothing/README.md)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The following manufacturers allow unlocking under certain conditions, such as re
 
 ### [Motorola/Lenovo](/brands/motorola/README.md)
 
+### [Google](/brands/google/README.md)
+
 ## ⚠️ Proceed with caution!
 
 The following manufacturers require an online account and/or a waiting period before unlocking.
@@ -96,8 +98,6 @@ The following manufacturers require an online account and/or a waiting period be
 ### [itel](/brands/itel/README.md)
 
 ## ℹ️ "Safe for now" :trollface: 
-
-### [Google](/brands/google/README.md)
 
 ### [Nothing](/brands/nothing/README.md)
 

--- a/brands/google/README.md
+++ b/brands/google/README.md
@@ -1,11 +1,16 @@
 # Google
 
-* Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict **ℹ️ "Safe for now" :trollface:** (Pixel 8 and earlier)
+* Verdict: **⛔ Avoid!** (Pixel 9 and later)
 * [**🔓️ Unlock Guide**](/misc/generic-unlock.md)
 
 Allows unlocking on almost any non-carrier locked device, but is also a pioneer in making rooting and custom ROMs painful with things like Safety Net and Play Integrity. With the latest feat being RCS messaging which requires DEVICE integrity to work. (To prevent "spam", of course)
 
 Google is also one of the few OEMs to support [custom AVB keys](/README.md#custom-avb-keys).
 
+Despite all of this, Google has started [disabling AI features][disabled ai] upon unlocking the bootloader on the Pixel 9 series, even if you aren't rooted, and it's not related to Play Integrity, and it's likely that in later Pixel models they'll disable more features.
 ***
+Additional info provided by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 Authored by [melontini](https://github.com/melontini).
+
+[disabled ai]:https://xdaforums.com/t/pixel-screenshots-other-ai-features-dont-work-with-unlocked-bl.4688190/


### PR DESCRIPTION
Starting with the Pixel 9 series, Google will disable certain features on the phone upon unlocking the bootloader, and while it's only some AI features right now, it's very likely going to worsen in Android 16 and/or the Pixel 10. I'd consider this requiring a sacrifice to unlock, therefore giving Google the avoid status. 

_god if google is starting to restrict it, im scared for the future of Android at all_