### PR TITLE
Move OnePlus to "Safe for now"

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ The following manufacturers require an online account and/or a waiting period be
 
 ### [Microsoft](/brands/microsoft/README.md)
 
-### [OnePlus](/brands/oneplus/README.md)
-
 ### [Infinix](/brands/infinix/README.md)
 
 ### [Tecno](/brands/tecno/README.md)
@@ -100,6 +98,8 @@ The following manufacturers require an online account and/or a waiting period be
 ### [Google](/brands/google/README.md)
 
 ### [Nothing](/brands/nothing/README.md)
+
+### [OnePlus](/brands/oneplus/README.md)
 
 ### [Umidigi](/brands/umidigi/README.md)
 

--- a/brands/oneplus/README.md
+++ b/brands/oneplus/README.md
@@ -1,5 +1,7 @@
 # OnePlus
-- Verdict:  **⚠️ Proceed with caution!** </br>
+
+* Verdict **ℹ️ "Safe for now" :trollface:**
+* [**🔓️ Unlock Guide**](/misc/generic-unlock.md)
 
 All of OnePlus' phones are easily unlockable. 
 However, do tread with caution as OPPO and OnePlus have merged their codebases into a "unified codebase", so OnePlus can, at any time, disable their unlocks.


### PR DESCRIPTION
# Why should OnePlus be moved?

The description below the proceed with caution category reads:
> The following manufacturers require an online account and/or a waiting period before unlocking.

OnePlus require neither of those things.

# What about the merger with OPPO?

While it is certainly possible for OnePlus to end their unlock program someday, demoting them to the proceed with caution tier strictly based off their connection to OPPO is just fearmongering, and can be outright misleading to readers.

They're not any more or less likely to "pull an OPPO" than other brands on the list. The title, "Safe **for now**", also makes it clear that the list's only job is to adhere to current values and not worry about any radical changes that might take place in the future, as could happen with other manufacturers.