### PR TITLE
Rewrite Microsoft's Android section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ The following manufacturers require an online account and/or a waiting period be
 
 ### [Sony](/brands/sony/README.md)
 
-### [Microsoft](/brands/microsoft/README.md)
-
 ### [Infinix](/brands/infinix/README.md)
 
 ### [Tecno](/brands/tecno/README.md)
@@ -100,6 +98,8 @@ The following manufacturers require an online account and/or a waiting period be
 ### [Nothing](/brands/nothing/README.md)
 
 ### [OnePlus](/brands/oneplus/README.md)
+
+### [Microsoft](/brands/microsoft/README.md)
 
 ### [Umidigi](/brands/umidigi/README.md)
 

--- a/brands/microsoft/README.md
+++ b/brands/microsoft/README.md
@@ -1,13 +1,13 @@
 # Microsoft
 
-- Verdict: **⚠️ Proceed with caution!**
+* Verdict **ℹ️ "Safe for now" :trollface:**
+* [**🔓️ Unlock Guide (Android devices)**](/misc/generic-unlock.md)
 
-While Microsoft doesn't provide an official unlocking method, an [unofficial method][android-unlock] has been available for their Android devices basically ever since Microsoft began making Android phones, and Microsoft hasn't bothered to patch it, and Windows is possible to run on an unlocked bootloader Surface Duo, so it seems like the bootloader will remain unlockable for now, but do note Microsoft can patch the unofficial method at any time.
+Despite Microsoft normally being a very anti-consumer company, the Surface Duo and Duo 2 are unlockable via the [standard unlock procedure](/misc/general-unlock.md).
 
-As for Windows Phones, once again, no official methods, but an [unofficial method][win-phone-unlock] has been around for a while, and supports all Mirosoft-made Lumias except for the 540 and 535, as Windows Phone hasn't been supported since 2017, it is highly unlikely this is going to be patched.
+As for Windows Phones, there are no official methods, but an [unofficial method][win-phone-unlock] has been around for a while, and supports all Mirosoft-made Lumias except for the 540 and 535, as Windows Phone hasn't been supported since 2017, it is highly unlikely this is going to be patched.
 
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 
-[android-unlock]:https://github.com/WOA-Project/SurfaceDuo-Guides/blob/main/Install/UnlockingBootloader.md
 [win-phone-unlock]:http://allaboutwindowsphone.com/features/item/24245_Aguideforunlockingthebootloade.php


### PR DESCRIPTION
Turns out that even though the Surface Duo devs recommend using their app, it's actually unneeded, I saw on some forums where people were saying the standard procedure was working for Microsoft's Android devices, and I confirmed with my girlfriend who owns a Surface Duo, and indeed, it can just be unlocked with flashing unlock. Since this is an official method, this also moves Microsoft to safe for now.