### PR TITLE
Added section on Motorola legal agreement and other improvements

### DIFF
--- a/brands/motorola/README.md
+++ b/brands/motorola/README.md
@@ -2,15 +2,15 @@
 
 - Verdict: **⛔ Avoid!**
 
-Motorola's [Bootloader Unlocking Legal Agreement](https://en-us.support.motorola.com/ci/fattach/get/741421/1385047216/redirect/1/filename/Boot_revised.pdf) includes a particularly concerning clause attempting to restrict the owner's rights after unlocking the bootloader.
+Motorola's [Bootloader Unlocking Legal Agreement][Bootloader Unlocking Legal Agreement] includes a particularly concerning clause attempting to restrict the owner's rights after unlocking the bootloader.
 
 The 4th clause of the agreement states:
 
 > User is unlocking the Device and/or altering the Device's software or operating system for his/her own personal use; User agrees not to transfer (i.e. sell, lease, or otherwise receive compensation from any third party for the right to use, possess, or operate such Device) such Device to any third party;
 
-This clause attempts to prohibit the user from selling, leasing, or otherwise transferring their own device after unlocking the bootloader. Such a restriction directly conflicts with established legal principles safeguarding ownership rights, namely the [First-Sale Doctrine](https://en.wikipedia.org/wiki/First-sale_doctrine) and the [Exhaustion Doctrine](https://en.wikipedia.org/wiki/Exhaustion_doctrine_under_U.S._law), which grant the owner the right to resell or dispose of property they have lawfully acquired. The legal validity of this clause is highly questionable and likely unenforceable. However, its inclusion in the agreement is a point of concern regarding post-sale control of hardware, and users should be aware of this term.
+This clause attempts to prohibit the user from selling, leasing, or otherwise transferring their own device after unlocking the bootloader. Such a restriction directly conflicts with established legal principles safeguarding ownership rights, namely the [First-Sale Doctrine][First-Sale Doctrine] and the [Exhaustion Doctrine][Exhaustion Doctrine], which grant the owner the right to resell or dispose of property they have lawfully acquired. The legal validity of this clause is highly questionable and likely unenforceable. However, its inclusion in the agreement is a point of concern regarding post-sale control of hardware, and users should be aware of this term.
 
-To unlock your bootloader, you have to submit a request on [this](https://en-us.support.motorola.com/app/standalone/bootloader/unlock-your-device-b) website, which is pretty bad on its own (*wink* [Huawei](/brands/huawei/README.md)). 
+To unlock your bootloader, you have to submit a request on [this][Unlock Code Website] website, which is pretty bad on its own (*wink* [Huawei](/brands/huawei/README.md)). 
 
 In addition, [this forum post][Old devices ineligible] says that once a device passes a certain age (the age not being specified), the device becomes ineligible.
 
@@ -47,6 +47,10 @@ CID info provided by [FPSensor](https://github.com/FPSensor).<br/>
 Unofficial ways to unlock "Moto G13/G23/G24/G24 Power" bootloader provided by [DiabloSat](https://github.com/progzone122) & [Shomy](https://github.com/shomykohai)<br />
 Authored by [melontini](https://github.com/melontini).
 
+[Bootloader Unlocking Legal Agreement]:https://en-us.support.motorola.com/ci/fattach/get/741421/1385047216/redirect/1/filename/Boot_revised.pdf
+[First-Sale Doctrine]:https://en.wikipedia.org/wiki/First-sale_doctrine
+[Exhaustion Doctrine]:https://en.wikipedia.org/wiki/Exhaustion_doctrine_under_U.S._law
+[Unlock Code Website]:https://en-us.support.motorola.com/app/standalone/bootloader/unlock-your-device-b
 [Most Devices]:https://en-us.support.motorola.com/app/answers/detail/a_id/87215
 [Some Devices]:https://en-us.support.motorola.com/app/standalone/bootloader/unlock-your-device-a
 [turistu's post]:https://xdaforums.com/t/how-to-guide-unlocking-using-deeptest-gdpr.4585829/post-88734665

--- a/brands/motorola/README.md
+++ b/brands/motorola/README.md
@@ -2,7 +2,15 @@
 
 - Verdict: **⛔ Avoid!**
 
-To start off, to unlock your bootloader you have to submit a request on their website, which is pretty bad on its own (*wink* [Huawei](/brands/huawei/README.md)). 
+Motorola's [Bootloader Unlocking Legal Agreement](https://en-us.support.motorola.com/ci/fattach/get/741421/1385047216/redirect/1/filename/Boot_revised.pdf) includes a particularly concerning clause attempting to restrict the owner's rights after unlocking the bootloader.
+
+The 4th clause of the agreement states:
+
+> User is unlocking the Device and/or altering the Device's software or operating system for his/her own personal use; User agrees not to transfer (i.e. sell, lease, or otherwise receive compensation from any third party for the right to use, possess, or operate such Device) such Device to any third party;
+
+This clause attempts to prohibit the user from selling, leasing, or otherwise transferring their own device after unlocking the bootloader. Such a restriction directly conflicts with established legal principles safeguarding ownership rights, namely the [First-Sale Doctrine](https://en.wikipedia.org/wiki/First-sale_doctrine) and the [Exhaustion Doctrine](https://en.wikipedia.org/wiki/Exhaustion_doctrine_under_U.S._law), which grant the owner the right to resell or dispose of property they have lawfully acquired. The legal validity of this clause is highly questionable and likely unenforceable. However, its inclusion in the agreement is a point of concern regarding post-sale control of hardware, and users should be aware of this term.
+
+To unlock your bootloader, you have to submit a request on [this](https://en-us.support.motorola.com/app/standalone/bootloader/unlock-your-device-b) website, which is pretty bad on its own (*wink* [Huawei](/brands/huawei/README.md)). 
 
 In addition, [this forum post][Old devices ineligible] says that once a device passes a certain age (the age not being specified), the device becomes ineligible.
 

--- a/brands/samsung/README.md
+++ b/brands/samsung/README.md
@@ -3,13 +3,13 @@
 - Verdict: **⛔ Avoid!**
 * [**🔓️ Unlock Guide (supported devices)**](/misc/samsung-unlock.md)
 
-If you have a North American device, well, uh... If you're lucky enough not to update for a while, you can check out [this paid service][Paid North American Unlock]. (At your own risk). Any phones prior to the S23 with an Exynos SoC can be unlocked if not carrier locked, regardless of region.
+If you have a North American device and were lucky enough not to update for a while, you can check out [this paid service][Paid North American Unlock] at your own risk. Any phones prior to the S23 with an Exynos SoC can be unlocked if not carrier locked, regardless of region.
 
 Snapdragon phones prior to the S7/Note7 (2016) can be unlocked regardless of region, as long as it's not locked to a carrier like AT&T or Verizon. The Canadian S7 can also be unlocked as it uses an Exynos SoC, despite Canada normally being a Snapdragon region.
 
-Be aware that unlocking a Samsung device will permanently trip Knox. As a result, many Knox-based features will be broken. This includes, but not limited to: Samsung Pay, Pass, Flow, Health, Secure Folder, Secure Wi-Fi, Smart View. Can you be denied warranty? Probably...
+Be aware that unlocking a Samsung device will permanently trip Knox. As a result, many Knox-based features will be broken. This includes, but not limited to: Samsung Pay, Pass, Flow, Health, Secure Folder, Secure Wi-Fi, Smart View. Furthermore, tripping Knox may serve as grounds for voiding your warranty.
 
-In the past, there have been hardware issues caused by unlocking the boatloader, but these have been fixed. [1][1] [2][2]
+In the past, there have been hardware issues caused by unlocking the boatloader, but these have been fixed. See [here][1] and [here][2].
 
 ## KnoxPatch
 


### PR DESCRIPTION
See Louis Rossmann's video for more details regarding the Motorola legal agreement:
https://www.youtube.com/watch?v=U2k9D81fbpA

The clause remains unchanged as of April 9, 2025:
https://en-us.support.motorola.com/ci/fattach/get/741421/1385047216/redirect/1/filename/Boot_revised.pdf

![Screenshot 2025-04-09 at 04-09-27 Unlocking the Bootloader Motorola Support US](https://github.com/user-attachments/assets/444c36ab-1248-404b-85c6-dc13312b6498)
