### PR TITLE
Cubot, Energizer and Itel don't share kernel sources

### DIFF
--- a/brands/cubot/README.md
+++ b/brands/cubot/README.md
@@ -6,6 +6,8 @@
 
 
 Cubot follows the [standard unlock procedure](/misc/generic-unlock.md) for their MediaTek devices, and the [Unisoc procedure][Unisoc Unlock] for their Unisoc devices.
+
+Cubot does not share the kernel source code for their devices. As the Linux kernel used in Android uses the GPLv2 license, the refusal to share the kernel source is a violation of copyright law and illegal. The lack of kernel source code severely limits the creation of custom ROMs, and can also at times make it more difficult to root or run GSIs.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 

--- a/brands/energizer/README.md
+++ b/brands/energizer/README.md
@@ -4,5 +4,7 @@
 
 Not only will Energizer destroy your electronics by leaking battery acid everywhere, but they will also destroy your privacy by not allowing you to unlock your bootloader. There's not much more to say, neither their Android phones or KaiOS phones are unlockable.
 
+Energizer does not share the kernel source code for their devices. As the Linux kernel used in Android and KaiOS uses the GPLv2 license, the refusal to share the kernel source is a violation of copyright law and illegal. The lack of kernel source code severely limits the creation of custom ROMs, and can also at times make it more difficult to root or run GSIs.
+
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).

--- a/brands/itel/README.md
+++ b/brands/itel/README.md
@@ -9,6 +9,8 @@ Itel [requires you to have an Itel ID](https://en.wikipedia.org/wiki/Bootloader_
 
 Earlier, itel didn't require online verification and two weeks of waiting. Things changed.
 
+itel does not share the kernel source code for their devices. As the Linux kernel used in Android uses the GPLv2 license, the refusal to share the kernel source is a violation of copyright law and illegal. The lack of kernel source code severely limits the creation of custom ROMs, and can also at times make it more difficult to root or run GSIs.
+
 See also: [Tecno](/brands/tecno/README.md)/[Infinix](/brands/infinix/README.md) - all subsidiaries of [Transsion Holdings](https://en.wikipedia.org/wiki/Transsion)
 
 ***


### PR DESCRIPTION
While this doesn't directly affect bootloader unlocking (and therefore verdict remains the same), it makes it very difficult to port custom ROMs, and can sometimes affect rooting and GSIs if the kernel needs to be updated for whatever reason, and those 3 things are the main reasons someone would bootloader unlock, plus it's straight up illegal, so it should be mentioned.

Sidenote - The device that controls my insulin pump runs Android and the manufacturer of both the pump (Insulet) and the device (Nuu) don't share the kernel sources, which is surprising to me, how does such a large company get away with it? I was tempted to add Nuu to the wall of shame just out of spite, but I decided against it, they're not relevant enough to be added.