### PR TITLE
Added Info

### DIFF
--- a/brands/asus/README.md
+++ b/brands/asus/README.md
@@ -10,6 +10,9 @@ Following Asus's false claims of a bootloader unlock eventually coming back, a U
 
 Asus is still claiming the unlock site will come back eventuallly, but considering how long it's been closed, the anti-rollback, and them losing a lawsuit over their unlockable bootloader claims, it's safe to say it'll probably never come back.
 
+In addition, Chinese ROG phones sold under the Tecent ROG brand cannot be unlocked at all.
+
+
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 

--- a/brands/samsung/README.md
+++ b/brands/samsung/README.md
@@ -9,7 +9,7 @@ Snapdragon phones prior to the S7/Note7 (2016) can be unlocked regardless of reg
 
 Be aware that unlocking a Samsung device will permanently trip Knox. As a result, many Knox-based features will be broken. This includes, but not limited to: Samsung Pay, Pass, Flow, Health, Secure Folder, Secure Wi-Fi, Smart View. Furthermore, tripping Knox may serve as grounds for voiding your warranty.
 
-In the past, there have been hardware issues caused by unlocking the boatloader, but these have been fixed. See [here][1] and [here][2].
+In the past, there have been hardware issues caused by unlocking the boatloader, but these have been fixed for some regions. See [here][1] and [here][2]. As of late 2023, Kroean Galaxy Fold3 running OneUI 5 still got camera disabled after unlocking, while EU/CN variants had fixed the issue.
 
 ## SoC level exploits
 One of the first things Samsung bootloaders do on phone bootup is check if the bootloader is unlocked, and if it is, and a bootloader unlock has not been authorized, the bootloader will automatically relock. This means SoC level exploits such as mtkclient or EDLUnlock will not work on Samsung devices, unless you reverse engineer, modify and re-flash Samsung's bootloader to stop the bootloader from re-locking. 


### PR DESCRIPTION
Added info about Galaxy Fold3 Korean variant still disables camera after unlocking.
Added info. about Chinese ROG phones that never could be unlocked since the birth of earth.
