### PR TITLE
Unisoc is no longer unlockable

### DIFF
--- a/brands/blackview/README.md
+++ b/brands/blackview/README.md
@@ -1,12 +1,11 @@
 # Blackview 
 
-* Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict **ℹ️ "Safe for now" :trollface:** (MediaTek)
+* Verdict: **🍅 Terrible!** (Unisoc)
 * [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
-* [**🔓️ Unlock Guide (Unisoc)**][Unisoc Unlock]
 
 
-Blackview follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices, and the [Unisoc procedure][Unisoc Unlock] for their Unisoc devices.
+Blackview follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices. Unisoc devices cannot be unlocked, this is *not* Blackview's fault, Unisoc does not allow unlocking.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/cubot/README.md
+++ b/brands/cubot/README.md
@@ -1,15 +1,14 @@
 # Cubot 
 
-* Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict **ℹ️ "Safe for now" :trollface:** (MediaTek)
+* Verdict: **🍅 Terrible!** (Unisoc)
 * [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
-* [**🔓️ Unlock Guide (Unisoc)**][Unisoc Unlock]
 
 
 
-Cubot follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices, and the [Unisoc procedure][Unisoc Unlock] for their Unisoc devices.
+Cubot follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices. Unisoc devices cannot be unlocked, this is *not* Cubot's fault, Unisoc does not allow unlocking.
 
 Cubot does not share the kernel source code for their devices. This is a violation of the GPLv2 license used in the Linux kernel. The lack of kernel source code severely limits the creation of custom ROMs, and can also at times make it more difficult to root or run GSIs.
 
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/honor/README.md
+++ b/brands/honor/README.md
@@ -1,8 +1,9 @@
 # Honor
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc/Spreadtrum)
 
-Following Honor's split from Huawei in 2020, Honor re-introduced the unlock command in fastboot, however when you run it, it'll act like the bootloader has been unlocked, but it [won't actually unlock][fake unlock]. Possibly Honor is slowly re-adding unlocks? No one really knows. Someone in that thread also claims they managed to unlock their bootloader, so maybe bootloaders are unlockable. Best off to avoid Honor for now but things could improve in the future for them. 
+Following Honor's split from Huawei in 2020, Honor re-introduced the unlock command in fastboot, however when you run it, it'll act like the bootloader has been unlocked, but it [won't actually unlock][fake unlock]. Possibly Honor is slowly re-adding unlocks? No one really knows. Someone in that thread also claims they managed to unlock their bootloader, so maybe bootloaders are unlockable. Best off to avoid Honor for now but things could improve in the future for them. Unisoc and Spreadtrum devices will never be unlockable, this is *not* Honor's fault, Unisoc/Spreadtrum does not allow unlocking.
 
 Certain Kirin-based phones can use [PotatoNV]
 

--- a/brands/htc/README.md
+++ b/brands/htc/README.md
@@ -1,9 +1,9 @@
 # HTC
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc/Spreadtrum)
 
-In the past, HTC allowed you to unlock your bootloader on their [developer website], but in June 2018 for whatever reason, HTC announced that any new phones would not have unlockable bootloaders, however their developer website would remain up for older devices.
-
+In the past, HTC allowed you to unlock your bootloader on their [developer website], but in June 2018 for whatever reason, HTC announced that any new phones would not have unlockable bootloaders, however their developer website would remain up for older devices. Unisoc and Spreadtrum devices will never be unlockable, this is *not* HTC's fault, Unisoc/Spradtrum does not allow unlocking.
 > [!NOTE]
 > As of September 2024, the website is still up and working (tested with an HTC Raider), however since HTC hasn't supported it in over 6 years, it may go down at any time, and even for these legacy devices, BS applies. 
 

--- a/brands/infinix/README.md
+++ b/brands/infinix/README.md
@@ -1,8 +1,9 @@
 # Infinix
 
-- Verdict: **⚠️ Proceed with caution!**
+- Verdict: **⚠️ Proceed with caution!** (MediaTek)
+- Verdict: **🍅 Terrible!** (Unisoc/Spreadtrum)
 
-Infinix does allow you to unlock your bootloader, but similarly to Motorola, [you must wait two weeks][Infinix unlock] before you can unlock the bootloader. For models with a Unisoc SoC, you will have to follow the [Hovatek guide][Unisoc Unlock] to unlock your bootloader.
+Infinix does allow you to unlock your bootloader, but similarly to Motorola, [you must wait two weeks][Infinix unlock] before you can unlock the bootloader. For models with a Unisoc SoC, you will have to follow the [Hovatek guide][Unisoc Unlock] to unlock your bootloader. Unisoc devices cannot be unlocked, this is *not* Infinix's fault, Unisoc does not allow unlocking.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 

--- a/brands/itel/README.md
+++ b/brands/itel/README.md
@@ -1,11 +1,11 @@
 # itel 
 
 - Verdict: **⚠️ Proceed with caution!**
+- Verdict: **🍅 Terrible!** (Unisoc)
 
 * [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
-* [**🔓️ Unlock Guide (Unisoc)**][Unisoc Unlock]
 
-Itel [requires you to have an Itel ID](https://en.wikipedia.org/wiki/Bootloader_unlocking) for two weeks before the OEM Unlocking option becomes available in the settings. Afterwards, you can follow the [standard unlock guide](../../misc/generic-unlock.md) for devices with a MediaTek SoC, or the [Unisoc unlock guide][Unisoc Unlock] for models with a Unisoc SoC.
+Itel [requires you to have an Itel ID](https://en.wikipedia.org/wiki/Bootloader_unlocking) for two weeks before the OEM Unlocking option becomes available in the settings. Afterwards, you can follow the [standard unlock guide](../../misc/generic-unlock.md) for devices with a MediaTek SoC. Unisoc devices cannot be unlocked, this is *not* itel's fault, Unisoc does not allow unlocking.
 
 Earlier, itel didn't require online verification and two weeks of waiting. Things changed.
 
@@ -17,4 +17,3 @@ See also: [Tecno](../tecno/README.md)/[Infinix](../infinix/README.md) - all subs
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439) and [mtxadmin](https://github.com/mtxadmin).<br/>
 
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/lg/README.md
+++ b/brands/lg/README.md
@@ -1,8 +1,9 @@
 # LG
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc)
 
-In the past, LG had a developer portal which could be used to unlock phones on their website, however it only supported international models of their phones, but in December 2021, LG [announced][announcement-archive] the developer portal would be shutting down due to LG ending production of all phones. 
+In the past, LG had a developer portal which could be used to unlock phones on their website, however it only supported international models of their phones, but in December 2021, LG [announced][announcement-archive] the developer portal would be shutting down due to LG ending production of all phones. Unisoc devices will never be unlockable, this is *not* LG's fault, Unisoc does not allow unlocking.
 
 On some models (such as the Stylo 3 Plus and G6), the bootloader can still be unlocked via `fastboot oem unlock` **only if** [the phone is a T-Mobile model][t-mobile-unlock].
 

--- a/brands/micromax/README.md
+++ b/brands/micromax/README.md
@@ -1,9 +1,10 @@
 # Micromax
 
 * Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict: **🍅 Terrible!** (Unisoc/Spreadtrum)
 * [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
 
-Despite their sketchy past with using their OTA updater app to [deliver adware][Micromax adware], Micromax follows the [standard unlock procedure](../../misc/generic-unlock.md)
+Despite their sketchy past with using their OTA updater app to [deliver adware][Micromax adware], Micromax follows the [standard unlock procedure](../../misc/generic-unlock.md). Unisoc and Spreadtrum devices cannot be unlocked, this is *not* Micromax's fault, Unisoc/Spreadtrum does not allow unlocking.
 
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>

--- a/brands/motorola/README.md
+++ b/brands/motorola/README.md
@@ -1,8 +1,9 @@
 # Motorola/Lenovo
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc)
 
-To unlock your bootloader, you have to submit a request on [this][Unlock Code Website] website, which is pretty bad on its own (*wink* [Huawei](../huawei/README.md)). 
+To unlock your bootloader, you have to submit a request on [this][Unlock Code Website] website, which is pretty bad on its own (*wink* [Huawei](../huawei/README.md)). Unisoc devices will never be unlockable, this is *not* Motorola's fault, Unisoc does not allow unlocking.
 
 In addition, [this forum post][Old devices ineligible] says that once a device passes a certain age (the age not being specified), the device becomes ineligible.
 

--- a/brands/oukitel/README.md
+++ b/brands/oukitel/README.md
@@ -1,12 +1,11 @@
 # Oukitel 
 
 * Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict: **🍅 Terrible!** (Unisoc)
 * [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
-* [**🔓️ Unlock Guide (Unisoc)**][Unisoc Unlock]
 
 
-Oukitel follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices, and the [Unisoc procedure][Unisoc Unlock] for their Unisoc devices.
+Oukitel follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices. Unisoc devices cannot be unlocked, this is *not* Oukitel's fault, Unisoc does not allow unlocking.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/samsung/README.md
+++ b/brands/samsung/README.md
@@ -1,9 +1,10 @@
 # Samsung
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc/Spreadtrum)
 * [**🔓️ Unlock Guide (supported devices)**](../../misc/samsung-unlock.md)
 
-If you have a North American device and were lucky enough not to update for a while, you can check out [this paid service][Paid North American Unlock] at your own risk. Any phones prior to the S23 with an Exynos SoC can be unlocked if not carrier locked, regardless of region.
+If you have a North American device and were lucky enough not to update for a while, you can check out [this paid service][Paid North American Unlock] at your own risk. Any phones prior to the S23 with an Exynos SoC can be unlocked if not carrier locked, regardless of region. Unisoc and Spreadtrum devices will never be unlockable, this is *not* Samsung's fault, Unisoc/Spreadtrum does not allow unlocking.
 
 Snapdragon phones prior to the S7/Note7 (2016) can be unlocked regardless of region, as long as it's not locked to a carrier like AT&T or Verizon. The Canadian S7 can also be unlocked as it uses an Exynos SoC, despite Canada normally being a Snapdragon region.
 

--- a/brands/tecno/README.md
+++ b/brands/tecno/README.md
@@ -1,10 +1,10 @@
 # Tecno 
 
 - Verdict: **⚠️ Proceed with caution!**
+- Verdict: **🍅 Terrible!** (Unisoc)
 
-Tecno requires you to have a [Tecno ID][Tecno ID] for two weeks before the OEM Unlocking option becomes available in the settings. Afterwards, you can follow the [standard unlock guide](../../misc/generic-unlock.md) for devices with a MediaTek SoC, or the [Unisoc unlock guide][Unisoc Unlock] for models with a Unisoc SoC.
+Tecno requires you to have a [Tecno ID][Tecno ID] for two weeks before the OEM Unlocking option becomes available in the settings. Afterwards, you can follow the [standard unlock guide](../../misc/generic-unlock.md) for devices with a MediaTek SoC. Unisoc devices cannot be unlocked, this is *not* Tecno's fault, Unisoc does not allow unlocking.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
 
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html
 [Tecno ID]:https://xdaforums.com/t/guide-rooting-tecno-spark-20-kj5n-twrp-custom-recovery.4667636/

--- a/brands/ulefone/README.md
+++ b/brands/ulefone/README.md
@@ -1,12 +1,10 @@
 # Ulefone 
 
 * Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict: **🍅 Terrible!** (Unisoc)
 * [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
-* [**🔓️ Unlock Guide (Unisoc)**][Unisoc Unlock]
 
 
-Ulefone follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices, and the [Unisoc procedure][Unisoc Unlock] for their Unisoc devices.
+Ulefone follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices. Unisoc devices cannot be unlocked, this is *not* Ulefone's fault, Unisoc does not allow unlocking.
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
-
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/umidigi/README.md
+++ b/brands/umidigi/README.md
@@ -1,12 +1,11 @@
 # Umidigi
 
 * Verdict **ℹ️ "Safe for now" :trollface:**
+* Verdict: **🍅 Terrible!** (Unisoc)
+* [**🔓️ Unlock Guide (MediaTek)**](../../misc/generic-unlock.md)
 
-Umidigi phones are generally unlockable, however due to them being a budget-focused manufacturer, they use Unisoc SoCs, and Unisoc requires a bunch of [extra steps to unlock][Unisoc Unlock] for whatever reason, and therefore I wouldn't consider them completely safe. 
 
-MediaTek devices can follow the [**🔓️ Generic Unlock Guide**](../../misc/generic-unlock.md).
+Umidigi follows the [standard unlock procedure](../../misc/generic-unlock.md) for their MediaTek devices. Unisoc devices cannot be unlocked, this is *not* Umidigi's fault, Unisoc does not allow unlocking.
 
 ***
 Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439).<br/>
-
-[Unisoc Unlock]:https://www.hovatek.com/forum/thread-32287.html

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -1,12 +1,15 @@
 # Xiaomi/Redmi/POCO
 
 - Verdict: **⛔ Avoid!**
+- Verdict: **🍅 Terrible!** (Unisoc)
 
 In the past, Xiaomi allowed most of its devices to be unlocked after a period of 7+ days (depending on how new the device is).
 
 With the launch of Xiaomi's new Android fork, HyperOS, they have introduced a number of changes to the unlock process, with new device limits and Mi Account requirements.
 
 Look here if you want to learn about how Ximi's bootloader works: [Xiaomi-bootloader]
+
+Unisoc devices will never be unlockable, this is *not* Xiaomi's fault, Unisoc does not allow unlocking.
 
 ### China
 


### PR DESCRIPTION
Unisoc themselves has begun removing the ability to unlock their bootloaders, I've added a warning to any brand that has used Unisoc/Spreadtrum saying devices with their SoCs cannot be unlocked, regardless of manufacturer.

Only discovered this after i got a Ulefone with a Unisoc T603. At least it was a free phone ig