### PR TITLE
feat: Add Shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The following manufacturers require an online account and/or a waiting period be
 ### [Volla](./brands/volla/README.md)
 
 ### [Teracube](./brands/teracube/README.md)
+
+### [Shift](./brands/shift/README.md)
+
 # Misc info
 
 ## Custom AVB Keys

--- a/brands/shift/README.md
+++ b/brands/shift/README.md
@@ -1,0 +1,10 @@
+# Shift 
+
+* Verdict **ℹ️ "Safe for now" :trollface:**
+* [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
+
+Shift Phones (https://shop.shiftphones.com/) can be unlocked via fastboot without any codes. The only requirement is 
+to enable **OEM unlocking** in **Developer Options** settings page. This is the same procedure as on Google Pixel. Shift also provides kernel sources to allow custom ROM's as their selling point.
+***
+Authored by [matu6968](https://github.com/matu6968).<br/>
+


### PR DESCRIPTION
- [Shift](https://shift.eco) is a German electronic manufacturer, which offers smartphones that can be unlocked, tablets and other electronic equipment like wireless speakers or headphones.
- Their smartphones run Android.
- They release kernel sources & their selling point is to offer custom ROM support.
- They are third-party development friendly.

One issue already talked about Shift being unlockable (issue #91) so i decided to make a PR to implement the changes.