### PR TITLE
OnePlus: Chinese phones running ColorOS 16.0 and above are now not as easy to unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ As a rule, almost all carrier locked devices do not allow the bootloader to be u
 
 The following manufacturers allow unlocking under certain conditions, such as region, model, SOC, etc., or require a sacrifice to unlock.
 
-### [OnePlus](./brands/oneplus/README.md)
-
 ### [OPPO/Realme](./brands/oppo/README.md)
 
 ### [Xiaomi/Redmi/POCO](./brands/xiaomi/README.md)
@@ -100,6 +98,8 @@ The following manufacturers allow unlocking under certain conditions, such as re
 ## ⚠️ Proceed with caution!
 
 The following manufacturers require an online account and/or a waiting period before unlocking.
+
+### [OnePlus](./brands/oneplus/README.md)
 
 ### [Google/Nexus](./brands/google/README.md)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ As a rule, almost all carrier locked devices do not allow the bootloader to be u
 
 The following manufacturers allow unlocking under certain conditions, such as region, model, SOC, etc., or require a sacrifice to unlock.
 
+### [OnePlus](./brands/oneplus/README.md)
+
 ### [OPPO/Realme](./brands/oppo/README.md)
 
 ### [Xiaomi/Redmi/POCO](./brands/xiaomi/README.md)
@@ -98,8 +100,6 @@ The following manufacturers allow unlocking under certain conditions, such as re
 ## ⚠️ Proceed with caution!
 
 The following manufacturers require an online account and/or a waiting period before unlocking.
-
-### [OnePlus](./brands/oneplus/README.md)
 
 ### [Google/Nexus](./brands/google/README.md)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The following manufacturers allow unlocking under certain conditions, such as re
 
 The following manufacturers require an online account and/or a waiting period before unlocking.
 
+### [OnePlus](./brands/oneplus/README.md)
+
 ### [Google/Nexus](./brands/google/README.md)
 
 ### [Fairphone](./brands/fairphone/README.md)
@@ -114,8 +116,6 @@ The following manufacturers require an online account and/or a waiting period be
 ## ℹ️ "Safe for now" :trollface: 
 
 ### [Nothing](./brands/nothing/README.md)
-
-### [OnePlus](./brands/oneplus/README.md)
 
 ### [Microsoft](./brands/microsoft/README.md)
 

--- a/brands/oneplus/README.md
+++ b/brands/oneplus/README.md
@@ -1,6 +1,6 @@
 # OnePlus
 
-* Verdict **⛔ Avoid at all costs!**
+* Verdict **⚠️ Proceed with caution!**
 * Global phones or Chinese phones up to ColorOS 16.0: [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
 
 ## Global phones or Chinese phones up to ColorOS 16.0

--- a/brands/oneplus/README.md
+++ b/brands/oneplus/README.md
@@ -1,12 +1,22 @@
 # OnePlus
 
-* Verdict **ℹ️ "Safe for now" :trollface:**
-* [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
+* Verdict **⚠️ Proceed with caution!**
+* Global phones or Chinese phones up to ColorOS 16.0: [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
 
-All of OnePlus' phones are easily unlockable. 
-However, do tread with caution as OPPO and OnePlus have merged their codebases into a "unified codebase", so OnePlus can, at any time, disable their unlocks.
-This means OnePlus, at any time, can **completely pull an OPPO** and lock their unlock process.
+## Global phones or Chinese phones up to ColorOS 16.0
+All OnePlus phones on the global market, as well as Chinese models up to ColorOS 16.0, can be easily unlocked using the [standard procedure](../../misc/generic-unlock.md).
 
-OnePlus also used to provide Deep Testing for their SIM-locked devices in the US, however they have stopped doing this.
+## Chinese phones running ColorOS 16.0 and above
+According to the [OnePlus forum](https://bbs.oneplus.com/thread/1926504022886318086), for phones and tablets sold in mainland China, unlocking the bootloader is **only possible via an official application to join the “Deep Testing” program**.
+
+**Main requirements:**  
+- Account must be in good standing (no violations or restrictions)  
+- No application submitted in the past 30 days  
+- Device is not a corporate or carrier-customized model  
+
+> **Note:** These restrictions currently apply only to devices sold in mainland China. However, due to the unified OPPO–OnePlus codebase, similar restrictions may be introduced for global models in the future.
+
 ***
 Authored by [madeline-yana](https://github.com/madeline-yana).
+
+Information about the Deep Testing program by [DiabloSat](https://github.com/progzone122).

--- a/brands/oneplus/README.md
+++ b/brands/oneplus/README.md
@@ -1,6 +1,6 @@
 # OnePlus
 
-* Verdict **⚠️ Proceed with caution!**
+* Verdict **⛔ Avoid at all costs!**
 * Global phones or Chinese phones up to ColorOS 16.0: [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
 
 ## Global phones or Chinese phones up to ColorOS 16.0


### PR DESCRIPTION
OnePlus can no longer be considered safe!
Although this currently affects only the Chinese market, you do realize what could happen to other phones in the future, right?

Source: https://bbs.oneplus.com/thread/1926504022886318086