### PR TITLE
Add pyMiUnlockTool, 7d/186h → 3d/72h wait, MD touchups.

### DIFF
--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -113,7 +113,7 @@ As such, for as long as the option is available, you'll skip this community BS a
 * ~~[HyperSploit][hypersploit] is the newer option. This is a simple to use program with no external dependencies.~~ Confirmed as patched as of HyperOS version 2.0.203.0. Still works on old versions.
 * ~~[Xiaomi-HyperOS-BootLoader-Bypass][xiaomi-hyperos-bootLoader-bypass] is the original proof of concept, but it's written in PHP and it's cumbersome to set up.~~ Same as above.
 
-This will (for now) allow you to continue with the last of the **bad old MIUI days** steps, where you wait for 3 days and can then unlock your phone successfully.
+This will (for now) allow you to continue with the last of the **bad old MIUI days** steps, where you wait for 3 (used to be 7) days and can then unlock your phone successfully.
 Do NOT make a new request by pressing the button in the Settings app as that will undo you bypass (hypersploit, MiUnlockTool and Mi Unlock also mention this to you). The tool will make the needed request itself.
 The only thing you need to do is use Xiaomi's [official Mi Unlock][MiUnlock] or [offici5l][offici5l]'s [Python script][py-MiUnlockTool] after 3 days.
 


### PR DESCRIPTION
- Added a reference to offici5l's unlock script (eliminating the need for Windows for the last step in unlocking, letting Linux and MacOS users get in on the action, not a bypass in itself).
- Linked to Xiaomi's official Mi Unlock.
- Small formatting touchups, additional links and rewordings for more consistency across the document, e.g renaming "Mi Unlock tool" and variations thereof into "Xiaomi's official Mi Unlock" to better match how what it's officially called and distinguish from the Python script.
- At some point they reduced the wait time from 7 days to 3 days (72 hours), don't have a source on paw besides that We are currently in that exact wait.