### PR TITLE
oneplus: Add info about older Chinese devices

### DIFF
--- a/brands/oneplus/README.md
+++ b/brands/oneplus/README.md
@@ -1,12 +1,12 @@
 # OnePlus
 
 * Verdict **⚠️ Proceed with caution!**
-* Global phones or Chinese phones up to ColorOS 16.0: [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
+* Global phones or Chinese phones released with ColorOS 15 or older: [**🔓️ Unlock Guide**](../../misc/generic-unlock.md)
 
-## Global phones or Chinese phones up to ColorOS 16.0
-All OnePlus phones on the global market, as well as Chinese models up to ColorOS 16.0, can be easily unlocked using the [standard procedure](../../misc/generic-unlock.md).
+## Global phones and older Chinese models
+All OnePlus phones on the global market, and any Chinese models that were initially released with ColorOS 15 or older, can be easily unlocked using the [standard procedure](../../misc/generic-unlock.md). This includes devices that have since updated to ColorOS 16.0 or newer.
 
-## Chinese phones running ColorOS 16.0 and above
+## Newer Chinese phones initially released with ColorOS 16.0 and above
 According to the [OnePlus forum](https://bbs.oneplus.com/thread/1926504022886318086), for phones and tablets sold in mainland China, unlocking the bootloader is **only possible via an official application to join the “Deep Testing” program**.
 
 **Main requirements:**  
@@ -17,6 +17,6 @@ According to the [OnePlus forum](https://bbs.oneplus.com/thread/1926504022886318
 > **Note:** These restrictions currently apply only to devices sold in mainland China. However, due to the unified OPPO–OnePlus codebase, similar restrictions may be introduced for global models in the future.
 
 ***
-Authored by [madeline-yana](https://github.com/madeline-yana).
+Authored by [madeline-yana](https://github.com/madeline-yana) and [jotkauser](https://github.com/jotkauser).
 
 Information about the Deep Testing program by [DiabloSat](https://github.com/progzone122).


### PR DESCRIPTION
As of 2025-11-1 CN devices that released with ColorOS 15 or older can still be unlocked normally. The forum even states it's currently for the 15 and the Ace 3 and some OnePlus Pad.
I'm making this PR to include the missing information.