### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ The following manufacturers have made it completely impossible to unlock their d
 
 ### [Amazon](./brands/amazon/README.md)
 
-### [Apple](./brands/apple/README.md)
-
 ### [Asus](./brands/asus/README.md)
 
 ### [Cat](./brands/cat/README.md)
@@ -65,8 +63,6 @@ The following manufacturers have made it completely impossible to unlock their d
 ### [TCL/BlackBerry](./brands/tcl/README.md)
 
 ### [Vivo/IQOO](./brands/vivo/README.md)
-
-### [Windows phones](./brands/winphones/README.md)
 
 ### Carrier Locked Devices
 


### PR DESCRIPTION
 Update the readme to remove Microsoft's Windows Phone & Apple's iOS due to the following reasons:
- Windows Phone has been discontinued as of January 2020. Meaning they're not even providing software updates anymore to the devices.
- Apple, although true; no iOS user has ever considered installing an alternate OS (such as Android) on said devices.