### PR TITLE
samsung: add bootloader reverse engineering info

### DIFF
--- a/brands/samsung/README.md
+++ b/brands/samsung/README.md
@@ -138,7 +138,7 @@ If you want to unlock the bootloader, first update your phone to any firmware re
 
 
 ## SoC level exploits
-One of the first things Samsung bootloaders do on phone bootup is check if the bootloader is unlocked, and if it is, and a bootloader unlock has not been authorized, the bootloader will automatically relock. This means SoC level exploits such as mtkclient or EDLUnlock will not work on Samsung devices, unless you reverse engineer, modify and re-flash Samsung's bootloader to stop the bootloader from re-locking. 
+One of the first things Samsung bootloaders do on phone bootup is check if the bootloader is unlocked, and if it is, and a bootloader unlock has not been authorized, the bootloader will automatically relock. This means SoC level exploits such as mtkclient or EDLUnlock will not work on Samsung devices, unless you reverse engineer, modify and re-flash Samsung's bootloader to stop the bootloader from re-locking (something you cannot do because Samsung always verifies their bootloaders). 
 
 ## KnoxPatch
 


### PR DESCRIPTION
if a user flashes an unsigned bootloader, the device will not boot at all because samsung always verifies their bootloaders, no matter if the bootloader is unlocked or locked. this PR adds this info.